### PR TITLE
chore: bump wrangler compatibility_date

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,5 @@
 name = "image-editing-arena"
-compatibility_date = "2024-01-01"
+compatibility_date = "2026-01-12"
 assets = { directory = "./dist" }
 
 # Deploy to Replicate's Cloudflare account


### PR DESCRIPTION
This PR updates the `compatibility_date` in `wrangler.toml` to `2026-01-12`.

Keeping this value current ensures access to the latest Workers runtime features and bug fixes.

See: https://developers.cloudflare.com/workers/configuration/compatibility-dates/